### PR TITLE
[fix] 센터 생성 코드가 local에서만 동작하도록 수정

### DIFF
--- a/src/main/java/com/ongi/backend/common/initializer/CenterDataInitializer.java
+++ b/src/main/java/com/ongi/backend/common/initializer/CenterDataInitializer.java
@@ -11,6 +11,7 @@ import lombok.extern.slf4j.Slf4j;
 import org.apache.poi.ss.usermodel.*;
 import org.apache.poi.xssf.usermodel.XSSFWorkbook;
 import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Profile;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -22,6 +23,7 @@ import java.util.List;
 
 @Slf4j
 @Service
+@Profile("local")
 @RequiredArgsConstructor
 public class CenterDataInitializer {
 


### PR DESCRIPTION
## ✔️ 연관 이슈


## 📝 작업 내용

센터 생성 자동화 코드가  ec2에서는 메모리 초과를 일으켜 local에서만 동작하도록 수정

### 스크린샷 (선택)
